### PR TITLE
Fixed the HTML close markup for the LinkedIn icon - had double </i>

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
         <a href="#" class="twitter"><i class="bi bi-twitter"></i></a>
         <a href="#" class="facebook"><i class="bi bi-facebook"></i></a>
         <a href="#" class="instagram"><i class="bi bi-instagram"></i></a>
-        <a href="#" class="linkedin"><i class="bi bi-linkedin"></i></i></a>
+        <a href="#" class="linkedin"><i class="bi bi-linkedin"></i></a>
       </div>
     </div>
   </section><!-- End Top Bar -->


### PR DESCRIPTION
This is a minor fix, but worthy to send as it raised warnings in webpack configured environments.

`<a href="#" class="linkedin"><i class="bi bi-linkedin"></i></i></a>`

Should be:

`<a href="#" class="linkedin"><i class="bi bi-linkedin"></i></a>`